### PR TITLE
Makes resolv work with multiple ips

### DIFF
--- a/lib/unit_tests_utils/internal_dns.rb
+++ b/lib/unit_tests_utils/internal_dns.rb
@@ -1,6 +1,12 @@
 module UnitTestsUtils::InternalDNS
+  # <b>DEPRECATED:</b> Please use <tt>resolve_domain_name</tt> instead.
   def self.resolv(hostname)
-    `dig +short #{hostname} @#{nameserver_ip}`.strip
+    warn "[DEPRECATION] `resolv` is deprecated. Please use `resolve_domain_name` instead."
+    resolve_domain_name(hostname).first
+  end
+
+  def self.resolve_domain_name(hostname)
+    `dig +short #{hostname} @#{nameserver_ip}`.strip.split("\n")
   end
 
   def self.host_addresses(hostnames, port)


### PR DESCRIPTION
Some DNS names points to more than one ip address, this version chooses
the first address between the multiples that can be resolved.

The ideal here should be to return an array of IPs, but I am thinking it might break everyone tests.