### PR TITLE
Makes start params configurable

### DIFF
--- a/lib/unit_tests_utils/bosh.rb
+++ b/lib/unit_tests_utils/bosh.rb
@@ -25,8 +25,12 @@ module UnitTestsUtils::Bosh
     wait_for_task_to_finish(deployment_name)
   end
 
-  def self.start_instance(deployment_name, instance_name, index = '0')
-    `bosh --non-interactive -d #{deployment_name} start #{instance_name}/#{index} --force`
+  def self.start_instance(deployment_name, instance_name, index = '0', debug = true)
+    if debug
+      `bosh --non-interactive -d #{deployment_name} start #{instance_name}/#{index} --force`
+    else
+      `bosh --non-interactive -d #{deployment_name} start #{instance_name}/#{index} --force > /dev/null 2> /dev/null`
+    end
     exit_status=$?
 
     if !exit_status.nil? && exit_status.to_i > 0

--- a/lib/unit_tests_utils/bosh.rb
+++ b/lib/unit_tests_utils/bosh.rb
@@ -35,8 +35,8 @@ module UnitTestsUtils::Bosh
     wait_for_task_to_finish(deployment_name)
   end
 
-  def self.stop_instance(deployment_name, instance_name, index = '0')
-    `bosh --non-interactive -d #{deployment_name} stop #{instance_name}/#{index} --hard --force`
+  def self.stop_instance(deployment_name, instance_name, index = '0', params = "--hard --force")
+    `bosh --non-interactive -d #{deployment_name} stop #{instance_name}/#{index} #{params}`
     exit_status=$?
 
     if !exit_status.nil? && exit_status.to_i > 0

--- a/unit_tests_utils.gemspec
+++ b/unit_tests_utils.gemspec
@@ -2,8 +2,8 @@
 
 Gem::Specification.new do |s|
   s.name        = 'unit-tests-utils'
-  s.version     = '1.3.0'
-  s.date        = '2018-04-04'
+  s.version     = '1.4.0'
+  s.date        = '2018-04-25'
   s.summary     = 'Common unit tests utils'
   s.description = 'This gems includes all resources needed for the a9s BOSH release unit tests.'
   s.authors     = ['Michael Lieser', 'Dennis Groß', 'Lucas Pinto']


### PR DESCRIPTION
Default is --hard --force.
The start script has now an option to redirect the output to /dev/null.
This introduces a new version v1.4.0