### PR TITLE
Make the manifest instance_groups a public method

### DIFF
--- a/lib/unit_tests_utils/manifest.rb
+++ b/lib/unit_tests_utils/manifest.rb
@@ -107,8 +107,6 @@ class UnitTestsUtils::Manifest
     ig['networks'].push( { "name" => new_network }  )
   end
 
-  private
-
   def instance_group(instance_name)
     manifest['instance_groups']
       .select { |instance_group| instance_group['name'] == instance_name }


### PR DESCRIPTION
This helper method is quite useful and is giving information already available to the user of the instance.