### PR TITLE
Introduce RspecLogger

### DIFF
--- a/lib/unit_tests_utils.rb
+++ b/lib/unit_tests_utils.rb
@@ -5,5 +5,6 @@ module UnitTestsUtils
   autoload :InternalDNS, 'unit_tests_utils/internal_dns.rb'
   autoload :Manifest, 'unit_tests_utils/manifest.rb'
   autoload :PGWebServiceClient, 'unit_tests_utils/postgresql_web_service_client.rb'
+  autoload :RspecLogger, 'unit_tests_utils/rspec_logger.rb'
   autoload :Turbulence, 'unit_tests_utils/turbulence.rb'
 end

--- a/lib/unit_tests_utils/rspec_logger.rb
+++ b/lib/unit_tests_utils/rspec_logger.rb
@@ -1,0 +1,43 @@
+class UnitTestsUtils::RspecLogger
+
+  def initialize
+    @buffer = []
+    @live_log = !ENV['UNIT_TEST_DEBUG'].nil? && ENV['UNIT_TEST_DEBUG'] == "true"
+  end
+
+  @@instance = UnitTestsUtils::RspecLogger.new
+
+  def self.instance
+    @@instance
+  end
+
+  attr_reader :buffer
+
+  def debug(message)
+    method = caller_locations.first
+    append("[#{method.base_label}:#{method.lineno}] - #{message}")
+  end
+
+  def print
+    buffer.each do |message|
+      puts message
+    end
+  end
+
+  def clear
+    buffer.clear
+  end
+
+  private_class_method :new
+
+
+  attr_reader :live_log
+
+  def append(message)
+    if live_log
+      puts "#{(object_id << 1)} - #{message}"
+    else
+      buffer.push(message)
+    end
+  end
+end

--- a/spec/lib/unit_tests_utils/rspec_logger_spec.rb
+++ b/spec/lib/unit_tests_utils/rspec_logger_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+require_relative '../../../lib/unit_tests_utils'
+
+describe UnitTestsUtils::RspecLogger do
+  context 'when buffering' do
+    subject(:logger) { UnitTestsUtils::RspecLogger.instance }
+
+    before do
+      logger.debug('message0')
+      logger.debug('message1')
+    end
+
+    describe 'buffer' do
+      it 'buffers messages' do
+        expect(logger.buffer.length).to eql(2)
+      end
+    end
+
+    describe '#clear' do
+      it 'clears the buffer' do
+        logger.clear
+
+        expect(logger.buffer.length).to eql(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
RspecLogger is being used with our BOSH release RSpec tests. Every BOSH
release included this class (more or less with the same code base).
We're moving it to this library so we can share the code.