### PR TITLE
Return local job properties and global properties

### DIFF
--- a/lib/unit_tests_utils/manifest.rb
+++ b/lib/unit_tests_utils/manifest.rb
@@ -79,7 +79,21 @@ class UnitTestsUtils::Manifest
   end
 
   def properties
-    manifest['properties']
+    {}.tap do |merged_properties|
+      instance_groups = manifest.dig('instance_groups')
+      instance_groups.each do |instance|
+        instance.each do |key,value|
+          if key == "jobs"
+            value.each do |job|
+              property = job.dig('properties')
+              merged_properties.merge!(property)
+            end
+          end
+        end
+      end
+
+      merged_properties.merge!(manifest['properties'] || {})
+    end
   end
 
   # get_network returns the network of listed in the deployment manifest. This

--- a/spec/fixtures/manifest-with-both-global-local-properties.yml
+++ b/spec/fixtures/manifest-with-both-global-local-properties.yml
@@ -1,0 +1,19 @@
+---
+name: service-ha
+
+instance_groups:
+- name: database
+  jobs:
+    - name: job0
+      properties:
+        property0: 0
+- name: backup
+  jobs:
+    - name: job1
+      properties:
+        property1: 1
+
+properties:
+  consul:
+    dc: datacenter
+    domain: foo

--- a/spec/fixtures/manifest-with-local-properties-only.yml
+++ b/spec/fixtures/manifest-with-local-properties-only.yml
@@ -1,0 +1,14 @@
+---
+name: service-ha
+
+instance_groups:
+- name: database
+  jobs:
+    - name: job0
+      properties:
+        property0: 0
+- name: backup
+  jobs:
+    - name: job1
+      properties:
+        property1: 1

--- a/spec/lib/unit_tests_utils/manifest_spec.rb
+++ b/spec/lib/unit_tests_utils/manifest_spec.rb
@@ -187,10 +187,30 @@ describe UnitTestsUtils::Manifest do
   end
 
   describe "#properties" do
-    let(:manifest_properties) { { "consul" => { "dc" => "datacenter", "domain" => "foo" } } }
+    context "when global properties are present only" do
+      let(:manifest_properties) { { "consul" => { "dc" => "datacenter", "domain" => "foo" } } }
 
-    it "returns a hash of the properties" do
-      expect(manifest.properties).to eq manifest_properties
+      it "returns a hash including the global properties" do
+        expect(manifest.properties).to eq manifest_properties
+      end
+    end
+
+    context "when local properties are present only" do
+      let(:manifest_path) { Fixtures.file_path("manifest-with-local-properties-only.yml") }
+      let(:manifest_properties) { { 'property0' => 0, 'property1' => 1 } }
+
+      it "returns a hash including the local properties" do
+        expect(manifest.properties).to eq manifest_properties
+      end
+    end
+
+    context "when both local and global properties are present" do
+      let(:manifest_path) { Fixtures.file_path("manifest-with-both-global-local-properties.yml") }
+      let(:manifest_properties) { {"consul"=>{"dc"=>"datacenter", "domain"=>"foo"}, "property0"=>0, "property1"=>1} }
+
+      it "returns a hash including both the global and local properties" do
+        expect(manifest.properties).to eq manifest_properties
+      end
     end
   end
 


### PR DESCRIPTION
The newest BOSH directors support BOSH v2 manifests only and will not
deploy a manifest containing global properties anymore.
Therefore, we collect all local job properties and the global ones and
merge them together in one hash for the time being.
In the future we'll need to get rid of `properties` or at least access
properties similar to the Ops file path structure.

Co-authored-by: Robert Gogolok <gogolok@gmail.com>