### PR TITLE
[DSA-36] Adds method to run BOSH errands

### DIFF
--- a/lib/unit_tests_utils/bosh.rb
+++ b/lib/unit_tests_utils/bosh.rb
@@ -41,6 +41,11 @@ module UnitTestsUtils::Bosh
     wait_for_task_to_finish(deployment_name)
   end
 
+  def self.run_errand(deployment_name, errand_name)
+    execute_or_raise_error("bosh --non-interactive -d #{deployment_name} run-errand #{errand_name}", "Failed to run errand #{errand_name}")
+    wait_for_task_to_finish(deployment_name)
+  end
+
   def self.create_and_upload_dev_release(base_dir, release_name, version_prefix = '')
     version = dev_release_version(version_prefix)
     raw_json = execute_or_raise_error("bosh --json create-release --dir #{base_dir} --name #{release_name} --version #{version} --force", "Creating release failed")

--- a/spec/lib/unit_tests_utils/bosh_spec.rb
+++ b/spec/lib/unit_tests_utils/bosh_spec.rb
@@ -155,6 +155,24 @@ describe UnitTestsUtils::Bosh do
     end
   end
 
+  describe ".run_errand" do
+    let(:errand_name) { "myerrand" }
+
+    context "when deployment name and errand name is given" do
+      it "runs the errand" do
+        expect(UnitTestsUtils::Bosh).to receive(:execute_or_raise_error).once.
+          with("bosh --non-interactive -d #{deployment_name} run-errand #{errand_name}",
+               "Failed to run errand #{errand_name}").
+          and_return(nil)
+
+        expect(UnitTestsUtils::Bosh).to receive(:`).once.
+          with("bosh -d #{deployment_name} task > /dev/null 2>&1")
+
+        UnitTestsUtils::Bosh.run_errand(deployment_name, errand_name)
+      end
+    end
+  end
+
   describe ".create_and_upload_dev_release" do
     let(:base_dir) { './' }
     let(:release_path) { File.join(base_dir, 'dev_releases', release_name, "#{release_name}-#{release_version}.yml") }


### PR DESCRIPTION
This is necessary to execute furthe configuration on some deployments.
E.g., MinIO deployment can have an errand method run to create buckets.

Ticket: https://anynines.atlassian.net/browse/DSA-36