### PR TITLE
[DSA-36] Adds method to execute command on a sub shell

### DIFF
--- a/lib/unit_tests_utils.rb
+++ b/lib/unit_tests_utils.rb
@@ -1,5 +1,6 @@
 module UnitTestsUtils
   autoload :Bosh, 'unit_tests_utils/bosh.rb'
+  autoload :Cmd, 'unit_tests_utils/cmd.rb'
   autoload :Consul, 'unit_tests_utils/consul.rb'
   autoload :Git, 'unit_tests_utils/git.rb'
   autoload :InternalDNS, 'unit_tests_utils/internal_dns.rb'

--- a/lib/unit_tests_utils/cmd.rb
+++ b/lib/unit_tests_utils/cmd.rb
@@ -1,0 +1,14 @@
+require 'open3'
+
+module UnitTestsUtils::Cmd
+  # Executes a command on the local machine and throws an error if exit status is not 0 (success)
+  def self.exec(command, msg)
+    stdout, stderr, exit_status = Open3.capture3(command)
+    if !exit_status.nil? && exit_status.to_i > 0
+      raise CmdError.new("#{msg} - exit_status: #{exit_status}\nstdout: #{stdout}\nstderr: #{stderr}")
+    end
+    return stdout, stderr
+  end
+
+  class CmdError < StandardError; end
+end

--- a/spec/lib/unit_tests_utils/cmd_spec.rb
+++ b/spec/lib/unit_tests_utils/cmd_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe UnitTestsUtils::Cmd do
+  describe ".exec" do
+    let(:echo_output) { "echo_output\n" }
+    let(:error_message) { "error_message" }
+
+    context "when executing a command with error message" do
+      it "runs the command" do
+        stdout, stderr = UnitTestsUtils::Cmd.exec("echo #{echo_output}",
+                                                  msg: "Failed to execute echo")
+        expect(stdout).to eq(echo_output)
+        expect(stderr).to be_empty
+      end
+
+      it "failes when command exits is non successful" do
+        expect do
+          UnitTestsUtils::Cmd.exec("[ 2 -lt 1 ]", msg: error_message)
+        end.to raise_error UnitTestsUtils::Cmd::CmdError
+      end
+    end
+  end
+end


### PR DESCRIPTION
So we don't execute commands with back ticks when writing unit-tests and make it easier to treat failures during unit-tests execution.

Ticket: https://anynines.atlassian.net/browse/DSA-36