### PR TITLE
Add Helper Utils class

### DIFF
--- a/lib/unit_tests_utils/manifest.rb
+++ b/lib/unit_tests_utils/manifest.rb
@@ -1,6 +1,8 @@
 require 'yaml'
 
 class UnitTestsUtils::Manifest
+  autoload :Traversal, 'unit_tests_utils/traversal.rb'
+
   @@instances = {}
 
   attr_reader :path, :manifest, :additional_vars
@@ -78,21 +80,25 @@ class UnitTestsUtils::Manifest
     end
   end
 
-  def properties
-    {}.tap do |merged_properties|
-      instance_groups = manifest.dig('instance_groups')
-      instance_groups.each do |instance|
-        instance.each do |key,value|
-          if key == "jobs"
-            value.each do |job|
-              property = job.dig('properties')
-              merged_properties.merge!(property || {})
+  def properties(path = nil)
+    if !path.nil?
+      UnitTestsUtils::Manifest::Traversal.new(manifest).find(path)
+    else
+      {}.tap do |merged_properties|
+        instance_groups = manifest.dig('instance_groups')
+        instance_groups.each do |instance|
+          instance.each do |key,value|
+            if key == "jobs"
+              value.each do |job|
+                property = job.dig('properties')
+                merged_properties.merge!(property || {})
+              end
             end
           end
         end
-      end
 
-      merged_properties.merge!(manifest['properties'] || {})
+        merged_properties.merge!(manifest['properties'] || {})
+      end
     end
   end
 

--- a/lib/unit_tests_utils/traversal.rb
+++ b/lib/unit_tests_utils/traversal.rb
@@ -1,0 +1,41 @@
+class UnitTestsUtils::Manifest::Traversal
+  attr_reader :manifest
+
+  def initialize(yml_manifest)
+    @manifest = yml_manifest
+  end
+
+  def find(path)
+    traverse(manifest, path)
+  end
+
+  protected 
+
+  def traverse(manifest, path)
+    first, *rest = path.split('/').reject { |e| e.to_s.empty? }
+    rest = rest.join('/')
+
+    if rest == ""
+      if first.include?('=')
+        components = first.split('=')
+        found = manifest.find { |pair| pair[components.first] == components.last } 
+        return found
+      end
+      return manifest[first]
+    end  
+
+    if first.include?('=')
+      components = first.split('=')
+      found = manifest.find { |pair| pair[components.first] == components.last } 
+      return traverse(found, rest)
+    end
+
+    if manifest.is_a?(Hash)
+      if manifest.key?(first)
+        return traverse(manifest[first], rest)
+      end
+    end
+
+    raise NotImplementedError
+  end
+end

--- a/spec/lib/unit_tests_utils/traversal_spec.rb
+++ b/spec/lib/unit_tests_utils/traversal_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+describe UnitTestsUtils::Manifest::Traversal do
+  context "Traversal of manifest yml using BOSH ops path" do
+    [
+      {
+        h: { 'a' => 1 },
+        path: 'a',
+        expected: 1
+      },
+      {
+        h: { 'a' => { 'b' => 2 } },
+        path: '/a/b',
+        expected: 2
+      },
+      { 
+        h: {'a' => [{'b' => 'value'}]},
+        path: '/a/b=value',
+        expected: {'b' => 'value'}
+      },
+      {
+        h: { 'a' => [ { 'b' => 'value', 'c' => { 'd' => 'e'} }, { 'n' => 'value' } ] },
+        path: '/a/b=value/c',
+        expected: { 'd' => 'e'}
+      },
+      {
+        h: { 'a' => [ { 'b' => 'value', 'c' => { 'd' => 'e'} }, { 'n' => 'value' } ] },
+        path: '/a/b=value/c/d',
+        expected: 'e'
+      },
+      {
+        h: { 'a' => [ { 'b' => 'value', 'c' => { 'd' => { 'f' => 'e' } } } , { 'n' => 'value' }  ]  },
+        path: '/a/b=value/c/d/f',
+        expected: 'e'
+      },
+      {
+        h: { 'a' => [ { 'b' => 'value', 'c' => [ { 'e' => 'value'} ] }, { 'n' => 'value' } ] },
+        path: '/a/b=value/c/e=value',
+        expected: { 'e' => 'value' }
+      },
+    ].each do |entry|
+      it "Successful traversal of yaml objects using ops path syntax" do
+        expect(UnitTestsUtils::Manifest::Traversal.new(entry[:h]).find(entry[:path])).to eql(entry[:expected])
+      end
+    end
+
+    [
+      {
+        h: [ { 'a' => 'b' } ] ,
+        path: '/a/b'
+      },
+    ].each do |entry|
+        it "raises an exception when the object is not a hash" do
+      expect { UnitTestsUtils::Manifest::Traversal.new(entry[:h]).find(entry[:path]) }.to raise_error(NotImplementedError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Helper utils provides traversal of manifest properties using a ops file
path syntax for ease of use.