### PR TITLE
[DSA-37] Introduces ERB Template Render

### DIFF
--- a/lib/unit_tests_utils.rb
+++ b/lib/unit_tests_utils.rb
@@ -8,4 +8,5 @@ module UnitTestsUtils
   autoload :PGWebServiceClient, 'unit_tests_utils/postgresql_web_service_client.rb'
   autoload :RspecLogger, 'unit_tests_utils/rspec_logger.rb'
   autoload :Turbulence, 'unit_tests_utils/turbulence.rb'
+  autoload :TemplateRender, 'unit_tests_utils/template_render.rb'
 end

--- a/lib/unit_tests_utils/template_render.rb
+++ b/lib/unit_tests_utils/template_render.rb
@@ -1,0 +1,31 @@
+require 'erb'
+
+class UnitTestsUtils::TemplateRender
+  include ERB::Util
+
+  attr_reader :template_file
+
+  def initialize(template_file)
+    @template_file = File.read(template_file)
+  end
+
+  def render(vars = {})
+    bind = empty_binding
+
+    vars.each { |key, value| bind.local_variable_set(key, value) }
+
+    ERB.new(template_file).result(bind)
+  end
+
+  def save(dst_file, vars = {})
+    rendered_content = render(vars)
+
+    File.open(dst_file, "w") { |f| f.write(rendered_content) }
+  end
+
+  private
+
+  def empty_binding
+    binding
+  end
+end

--- a/spec/fixtures/template-with-vars.yml
+++ b/spec/fixtures/template-with-vars.yml
@@ -1,0 +1,4 @@
+---
+first_level:
+  first_entry: <%= first_var_content %>
+  second_entry: <%= second_var_content %>

--- a/spec/lib/unit_tests_utils/template_render_spec.rb
+++ b/spec/lib/unit_tests_utils/template_render_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+require 'yaml'
+
+describe UnitTestsUtils::TemplateRender do
+  let(:template) { 'spec/fixtures/template-with-vars.yml' }
+  let(:output_file) { '/tmp/template-with-vars.yml' }
+  let(:vars) do
+    {
+      first_var_content: 'first_content',
+      second_var_content: 'second_content'
+    }
+  end
+
+  subject { UnitTestsUtils::TemplateRender.new(template) }
+
+  it 'renders the template in an output file' do
+    result = subject.save(output_file, vars)
+    manifest = YAML.load_file(output_file)
+
+    expect(manifest['first_level']['first_entry']).to eq(vars[:first_var_content])
+    expect(manifest['first_level']['second_entry']).to eq(vars[:second_var_content])
+  end
+end


### PR DESCRIPTION
Handles .erb files to generate output files with parsed variables, which are used to created yaml manifests on the fly.

Ticket: https://anynines.atlassian.net/browse/DSA-37