### PR TITLE
Added find_in_deployment_manifest method

### DIFF
--- a/lib/unit_tests_utils/bosh.rb
+++ b/lib/unit_tests_utils/bosh.rb
@@ -1,5 +1,6 @@
 require 'json'
 require 'open3'
+require 'yaml'
 
 module UnitTestsUtils::Bosh
   def self.deploy(deployment_name, manifest_path, additional_vars = [], ops_files = [])
@@ -22,6 +23,16 @@ module UnitTestsUtils::Bosh
 
     execute_or_raise_error_in("bosh --non-interactive -d #{deployment_name} deploy #{vars}", manifest.manifest.to_yaml, "Deploy failed")
     wait_for_task_to_finish(deployment_name)
+  end
+
+  def self.find_in_deployment_manifest(deployment_name, ops_search_path = '')
+    manifest_as_str = execute_or_raise_error("bosh --non-interactive -d #{deployment_name} manifest", "Couldn't fetch deployment mainfest")
+    manifest = YAML.load(manifest_as_str)
+    if ops_search_path.empty? 
+      manifest
+    else
+      UnitTestsUtils::Manifest::Traversal.new(manifest).find(ops_search_path)
+    end
   end
 
   def self.delete_deployment(deployment_name)


### PR DESCRIPTION
The find_in_deploymnet_manifest method fetches the manifest of
a already deployed deployment and return a part of that manifest.
The returned part is defined by an ops-like search string.
The default value of that search string is nil.
If the search string is nil then it returns the whole manifest.