### PR TITLE
[Maintenance] Compatibility With the Latest BOSH CLI

### DIFF
--- a/lib/unit_tests_utils/bosh.rb
+++ b/lib/unit_tests_utils/bosh.rb
@@ -42,14 +42,14 @@ module UnitTestsUtils::Bosh
 
   def self.start_instance(deployment_name, instance_name, index = '0', debug = true)
     if debug
-      execute_or_raise_error("bosh --non-interactive -d #{deployment_name} start #{instance_name}/#{index} --force", "Starting instance failed")
+      execute_or_raise_error("bosh --non-interactive -d #{deployment_name} start #{instance_name}/#{index}", "Starting instance failed")
     else
-      execute_or_raise_error("bosh --non-interactive -d #{deployment_name} start #{instance_name}/#{index} --force > /dev/null 2> /dev/null", "Starting instance failed")
+      execute_or_raise_error("bosh --non-interactive -d #{deployment_name} start #{instance_name}/#{index} > /dev/null 2> /dev/null", "Starting instance failed")
     end
     wait_for_task_to_finish(deployment_name)
   end
 
-  def self.stop_instance(deployment_name, instance_name, index = '0', params = "--hard --force")
+  def self.stop_instance(deployment_name, instance_name, index = '0', params = "--hard --skip-drain")
     execute_or_raise_error("bosh --non-interactive -d #{deployment_name} stop #{instance_name}/#{index} #{params}", "Stopping instance failed")
     wait_for_task_to_finish(deployment_name)
   end

--- a/unit_tests_utils.gemspec
+++ b/unit_tests_utils.gemspec
@@ -2,13 +2,13 @@
 
 Gem::Specification.new do |s|
   s.name        = 'unit-tests-utils'
-  s.version     = '2.7.0'
-  s.date        = '2020-02-12'
+  s.version     = '2.8.0'
+  s.date        = '2020-12-15'
   s.summary     = 'Common unit tests utils'
   s.description = 'This gems includes all resources needed for the a9s BOSH release unit tests.'
   s.authors     = ['Michael Lieser', 'Dennis Groß', 'Lucas Pinto', 'Kevin Konrad',
                     'Jens Breuer', 'Khaled Blah', 'Morgan Hill', 'Thomas Bruckmann',
-                    'Robert Gogolok', 'Heitor Meira']
+                    'Robert Gogolok', 'Heitor Meira', 'Cedrik Heusser']
   s.email       = 'support@anynines.com'
   s.files       = [
     'lib/unit_tests_utils.rb',


### PR DESCRIPTION
We've updated our docker image to use the latests BOSH CLI.
Using the latest version included that some flag aren't supported
anymore. This PR removes the deprecated flags.