### PR TITLE
[DS-522] Supports '?' to indicate optional key

### DIFF
--- a/lib/unit_tests_utils/traversal.rb
+++ b/lib/unit_tests_utils/traversal.rb
@@ -12,7 +12,8 @@ class UnitTestsUtils::Manifest::Traversal
   protected
 
   def traverse(manifest, path)
-    first, *rest = path.split('/').reject { |e| e.to_s.empty? }
+    raw_first, *rest = path.split('/').reject { |e| e.to_s.empty? }
+    first = formatted_key(raw_first)
     rest = rest.join('/')
 
     if rest == ""
@@ -36,6 +37,18 @@ class UnitTestsUtils::Manifest::Traversal
       end
     end
 
-    raise NotImplementedError
+    raise NotImplementedError if !is_optional(first)
+  end
+
+  private
+
+  def is_optional(key)
+    key.end_with?('?')
+  end
+
+  def formatted_key(key)
+    return key.chop if is_optional(key)
+
+    key
   end
 end

--- a/spec/lib/unit_tests_utils/traversal_spec.rb
+++ b/spec/lib/unit_tests_utils/traversal_spec.rb
@@ -38,6 +38,16 @@ describe UnitTestsUtils::Manifest::Traversal do
         path: '/a/b=value/c/e=value',
         expected: { 'e' => 'value' }
       },
+      {
+        h: { 'a' => [ { 'b' => 'value', 'c' => { 'd' => 'e'} }, { 'n' => 'value' } ] },
+        path: '/a/b=value/c?/f?',
+        expected: nil
+      },
+      {
+        h: { 'a' => [ { 'b' => 'value', 'c' => { 'd' => 'e'} }, { 'n' => 'value' } ] },
+        path: '/a/b=value/c?',
+        expected: { 'd' => 'e' }
+      },
     ].each do |entry|
       it "Successful traversal of yaml objects using ops path syntax" do
         expect(UnitTestsUtils::Manifest::Traversal.new(entry[:h]).find(entry[:path])).to eql(entry[:expected])


### PR DESCRIPTION
When looking for a path that is not in the manifest, find will throw an exception by default.

This commit introduces support to '?' to indicate that a property might not exist, which in this case it should not throw an exception, but return nil.

This is particularly useful when testing one test case against different manifests (e.g. a9s PostgreSQL unit-tests).